### PR TITLE
Fix GitHub Pages asset paths for custom domain

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,8 @@ jobs:
         run: npm ci
 
       - name: Build site
+        env:
+          NEXT_PUBLIC_BASE_PATH: ""
         run: npm run build
 
       - name: Add .nojekyll

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,7 @@
 import type { NextConfig } from "next";
 
-const repositoryName = process.env.GITHUB_REPOSITORY?.split("/")[1] ?? "ghp-x.github.io";
-const isGitHubPages = process.env.GITHUB_ACTIONS === "true";
-const basePath = isGitHubPages ? `/${repositoryName}` : "";
+const configuredBasePath = process.env.NEXT_PUBLIC_BASE_PATH?.trim();
+const basePath = configuredBasePath || "";
 
 const nextConfig: NextConfig = {
   output: "export",


### PR DESCRIPTION
## Summary
- stop forcing a repository-based base path for the GitHub Pages export
- set the deploy workflow to use a root-relative base path for the custom domain
- verified the production build succeeds and generates the static site correctly

## Why
The site was losing its CSS and animation layer when served from the custom domain because the export config was still applying a GitHub repository subpath. This broke asset loading and left the page effectively as plain text.